### PR TITLE
unit checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ const DEFAULT_METRIC_OPTIONS = {
   sendCallback: () => {},
   maxCapacity: 20
 };
+//see http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
 const UNITS = {
     "SECONDS" : "Seconds",
     "MICROSECONDS" : "Microseconds",
@@ -158,8 +159,9 @@ function Metric(namespace, units, defaultDimensions, options) {
   self._storedMetrics = [];
 
   if (self.options.enabled) {
-        if(!Object.keys(UNITS).find(u=>UNITS[u]===units)) {
-        throw 'cloudwatch-metrics: Unrecognised unit';
+    const UNIT_VALS = _.values(UNITS);
+    if(!_.contains(UNIT_VALS, units)) {
+      throw 'cloudwatch-metrics: Unrecognized unit';
     }
     self._interval = setInterval(() => {
       self._sendMetrics();

--- a/spec/src/indexSpec.js
+++ b/spec/src/indexSpec.js
@@ -137,7 +137,21 @@ describe('cloudwatch-metrics', function() {
       metric.put(2, 'metricName', [{Name:'ExtraDimension',Value: 'Value'}]);
     });
   });
-
+  describe('unit checking', function() {
+    it('should error for unknown units', function () {
+      var error = false;
+      try {
+        var metric = new cloudwatchMetric.Metric('namespace', 'UnknownUnit', [{
+          Name: 'environment',
+          Value: 'PROD'
+        }]);
+        metric.put(1, 'metricName', [{Name:'ExtraDimension',Value: 'Value'}]);
+      }catch(e){
+        error = true;
+      }
+      expect(error).toBe(true);
+    });
+  });
   describe('sample', function() {
     it('should ignore metrics when not in the sample range', function() {
       var metric = new cloudwatchMetric.Metric('namespace', 'Count', [{


### PR DESCRIPTION
exports a UNITS constant which is based on the list of units here... http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html  also checks to see if incoming unit value is valid