### PR TITLE
Remove underscore dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@
  */
 
 var AWS = require('aws-sdk');
-var _ = require('underscore');
 
 var _awsConfig = {region: 'us-east-1'};
 /**
@@ -126,7 +125,7 @@ function Metric(namespace, units, defaultDimensions, options) {
   self.namespace = namespace;
   self.units = units;
   self.defaultDimensions = defaultDimensions || [];
-  self.options = _.defaults(options || {}, DEFAULT_METRIC_OPTIONS);
+  self.options = Object.assign({}, DEFAULT_METRIC_OPTIONS, options);
   self._storedMetrics = [];
 
   if (self.options.enabled) {
@@ -196,7 +195,7 @@ Metric.prototype._sendMetrics = function() {
   const dataPoints = self._storedMetrics;
   self._storedMetrics = [];
 
-  if (_.isEmpty(dataPoints)) return;
+  if (!dataPoints || !dataPoints.length) return;
 
   self.cloudwatch.putMetricData({
     MetricData: dataPoints,

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
   },
   "homepage": "https://github.com/mixmaxhq/cloudwatch-metrics#readme",
   "dependencies": {
-    "aws-sdk": "^2.4.14",
-    "underscore": "^1.8.3"
+    "aws-sdk": "^2.4.14"
   },
   "devDependencies": {
     "eslint": ">=3",
     "eslint-config-mixmax": "^0.6.0",
     "jasmine": "^2.5.2",
     "pre-commit": "^1.2.2",
-    "rewire": "^2.5.2"
+    "rewire": "^2.5.2",
+    "underscore": "^1.8.3"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
The use of underscore was minimal and I'd like to keep my packaged services that use this library as small as possible.

The `_.isEmpty()` was a simple replacement since `_storedMetrics` is always an array.

Replacing `_.defaults()` with `Object.assign()` does have the side effect of requiring node v4+. Most libraries are heading in that direction, so I feel that this is a safe change. If you'd rather keep support for node <4, then I suggest doing the work of `Object.assign` manually.
