### PR TITLE
Add timestamp to metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,7 @@ Metric.prototype.put = function(value, metricName, additionalDimensions) {
     self._storedMetrics.push({
       MetricName: metricName,
       Dimensions: self.defaultDimensions.concat(additionalDimensions),
+      Timestamp: Date.now(),
       Unit: self.units,
       Value: value
     });

--- a/spec/src/indexSpec.js
+++ b/spec/src/indexSpec.js
@@ -1,4 +1,4 @@
-/* globals describe, afterEach, it, expect, spyOn */
+/* globals describe, afterEach, it, expect, spyOn, jasmine */
 
 var _ = require('underscore');
 
@@ -36,6 +36,7 @@ describe('cloudwatch-metrics', function() {
               Value: 'Value'
             }],
             MetricName: 'metricName',
+            Timestamp: jasmine.any(Number),
             Unit: 'Count',
             Value: 1
           }],
@@ -67,6 +68,7 @@ describe('cloudwatch-metrics', function() {
               Value: 'Value'
             }],
             MetricName: 'metricName',
+            Timestamp: jasmine.any(Number),
             Unit: 'Count',
             Value: 1
           }],
@@ -103,6 +105,7 @@ describe('cloudwatch-metrics', function() {
               Value: 'Value'
             }],
             MetricName: 'metricName',
+            Timestamp: jasmine.any(Number),
             Unit: 'Count',
             Value: 1
           }, {
@@ -114,6 +117,7 @@ describe('cloudwatch-metrics', function() {
               Value: 'Value'
             }],
             MetricName: 'metricName',
+            Timestamp: jasmine.any(Number),
             Unit: 'Count',
             Value: 2
           }],


### PR DESCRIPTION
+ Add timestamp to each metric at "put" time so CloudWatch does not generate one at publish time

Having timestamps at publish time would force all timestamps to be the same (or close to)