### PR TITLE
limit max capacity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ node_js:
 
 sudo: false
 
+script:
+  - npm run lint
+  - npm run test
+
 # Don't build pushes to branches other than our deploy branches. (This doesn't
 # affect PR builds, which are separate from branch builds in Travis. If we
 # didn't have this config, Travis would run both types of builds for PRs,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AWS credentials from the AWS SDK's [default environment variables](http://docs.a
 If you want to change these values, you can call `initialize`:
 
 ```js
-var cloudwatchMetrics = require('cloudwatch-metrics');
+const cloudwatchMetrics = require('cloudwatch-metrics');
 cloudwatchMetrics.initialize({
 	region: 'us-east-1'
 });
@@ -31,14 +31,14 @@ cloudwatchMetrics.initialize({
 For creating a metric, we simply need to provide the
 namespace and the type of metric:
 ```js
-var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count');
+const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count');
 ```
 
 ### Metric creation - w/ default dimensions
 If we want to add our own default dimensions, such as environment information,
 we can add it in the following manner:
 ```js
-var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
 	Name: 'environment',
 	Value: 'PROD'
 }]);
@@ -49,9 +49,9 @@ If we want to disable a metric in certain environments (such as local developmen
 we can make the metric in the following manner:
 ```js
 // isLocal is a boolean
-var isLocal = someWayOfDetermingIfLocal();
+const isLocal = someWayOfDetermingIfLocal();
 
-var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
 	Name: 'environment',
 	Value: 'PROD'
 }], {
@@ -66,7 +66,7 @@ Option | Purpose
 enabled | Whether or not we should send the metric to CloudWatch (useful for dev vs prod environments).
 sendInterval | The interval in milliseconds at which we send any buffered metrics, defaults to 5000 milliseconds.
 sendCallback | A callback to be called when we send metric data to CloudWatch (useful for logging any errors in sending data).
-maxCapacity | A maximum number of events to buffer before we send immediately (before the sendInterval is reached).
+maxCapacity | A maximum number of events to buffer before we send immediately (before the sendInterval is reached). AWS has a hard limit of 20 per Request. Above that it will reject your metrics and they will be lost.
 
 ### Publishing metric data
 Then, whenever we want to publish a metric, we simply do:
@@ -84,7 +84,7 @@ request size percentiles. You could use `summaryPut` to track this data and send
 it to CloudWatch with fewer requests:
 
 ```js
-var metric = new cloudwatchMetrics.Metric('namespace', 'Bytes');
+const metric = new cloudwatchMetrics.Metric('namespace', 'Bytes');
 
 function onRequest(req) {
 	// This will still track maximum, minimum, sum, count, and average, but won't
@@ -98,7 +98,7 @@ the order of the dimensions is significant!_ In other words, these track
 different metric sets:
 
 ```js
-var metric = new cloudwatchMetrics.Metric('namespace', 'Bytes');
+const metric = new cloudwatchMetrics.Metric('namespace', 'Bytes');
 // Different statistic sets!
 metric.summaryPut(45, 'requestSize', [{Name: 'Region', Value: 'US'}, {Name: 'Server', Value: 'Card'}]);
 metric.summaryPut(894, 'requestSize', [{Name: 'Server', Value: 'Card'}, {Name: 'Region', Value: 'US'}]);
@@ -114,7 +114,7 @@ sent at a different interval, then provide that option when constructing your
 CloudWatch Metric:
 
 ```js
-var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
 	Name: 'environment',
 	Value: 'PROD'
 }], {
@@ -125,7 +125,7 @@ var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
 You can also register a callback to be called when we actually send metrics
 to CloudWatch - this can be useful for logging put-metric-data errors:
 ```js
-var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
 	Name: 'environment',
 	Value: 'PROD'
 }], {

--- a/index.js
+++ b/index.js
@@ -246,7 +246,9 @@ Metric.prototype._sendMetrics = function() {
  */
 Metric.prototype.shutdown = function() {
   clearInterval(this._interval);
+  clearInterval(this._summaryInterval);
   this._sendMetrics();
+  this._summarizeMetrics();
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * CloudWatch metrics. We should always initialize our environment first:
  *
  * ```
- * var cloudwatchMetrics = require('cloudwatch-metrics');
+ * const cloudwatchMetrics = require('cloudwatch-metrics');
  * cloudwatchMetrics.initialize({
  * 	region: 'us-east-1'
  * });
@@ -13,14 +13,14 @@
  * namespace and the type of metric:
  *
  * ```
- * 	var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count');
+ * 	const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count');
  * ```
  *
  * If we want to add our own default dimensions, such as environment information,
  * we can add it in the following manner:
  *
  * ```
- * var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+ * const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
  * 	Name: 'environment',
  * 	Value: 'PROD'
  * }]);
@@ -31,9 +31,9 @@
  *
  * ```
  * // isLocal is a boolean
- * var isLocal = someWayOfDetermingIfLocal();
+ * const isLocal = someWayOfDetermingIfLocal();
  *
- * var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+ * const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
  * 	Name: 'environment',
  * 	Value: 'PROD'
  * }], {
@@ -56,7 +56,7 @@
  * CloudWatch Metric:
  *
  * ```
- * var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+ * const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
  * 	Name: 'environment',
  * 	Value: 'PROD'
  * }], {
@@ -67,7 +67,7 @@
  * You can also register a callback to be called when we actually send metrics
  * to CloudWatch - this can be useful for logging put-metric-data errors:
  * ```
- * var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
+ * const myMetric = new cloudwatchMetrics.Metric('namespace', 'Count', [{
  * 	Name: 'environment',
  * 	Value: 'PROD'
  * }], {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A simple wrapper for simplifying using Cloudwatch metrics",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/jasmine",
-    "lint": "./node_modules/.bin/eslint ."
+    "test": "jasmine",
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A simple wrapper for simplifying using Cloudwatch metrics",
   "main": "index.js",
   "scripts": {
-    "test": "jasmine",
-    "lint": "eslint ."
+    "test": "./node_modules/.bin/jasmine",
+    "lint": "./node_modules/.bin/eslint ."
   },
   "repository": {
     "type": "git",

--- a/spec/src/indexSpec.js
+++ b/spec/src/indexSpec.js
@@ -37,7 +37,7 @@ describe('cloudwatch-metrics', () => {
 
   function putMetric(metric, amount) {
     for (let i = 1; i <= amount; i++) {
-      metric.put(i, 'metricName', [{Name:'ExtraDimension',Value: 'Value'}]);
+      metric.put(i, 'metricName', [{Name: 'ExtraDimension', Value: 'Value'}]);
     }
   }
 
@@ -189,7 +189,7 @@ describe('cloudwatch-metrics', () => {
         cb();
       });
 
-      var metric = new cloudwatchMetric.Metric('namespace', 'Count', [{
+      const metric = new cloudwatchMetric.Metric('namespace', 'Count', [{
         Name: 'environment',
         Value: 'PROD'
       }], {
@@ -224,7 +224,7 @@ describe('cloudwatch-metrics', () => {
         cb();
       });
 
-      var metric = new cloudwatchMetric.Metric('namespace', 'Count', [{
+      const metric = new cloudwatchMetric.Metric('namespace', 'Count', [{
         Name: 'environment',
         Value: 'PROD'
       }], {
@@ -249,7 +249,7 @@ describe('cloudwatch-metrics', () => {
       spyOn(Math, 'random').and.returnValue(0.5);
       spyOn(metric, 'put');
 
-      metric.sample(1, 'metricName', [{Name:'ExtraDimension',Value: 'Value'}], 0.2);
+      metric.sample(1, 'metricName', [{Name: 'ExtraDimension', Value: 'Value'}], 0.2);
       expect(metric.put).not.toHaveBeenCalled();
     });
 
@@ -263,7 +263,7 @@ describe('cloudwatch-metrics', () => {
       // Just so we don't send anything to AWS.
       spyOn(metric, 'put').and.returnValue(undefined);
 
-      metric.sample(1, 'metricName', [{Name:'ExtraDimension',Value: 'Value'}], 0.2);
+      metric.sample(1, 'metricName', [{Name: 'ExtraDimension', Value: 'Value'}], 0.2);
       expect(metric.put).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
I stumbled upon the issue, that on production I had way less metric points in my chart as on testing. Since the usage on production is higher this looked weird. After investigating I found a lot of errors about failed requests and therefore the limitation of 20 metrics per request https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html. Due to that I lost a lot of metric points. To prevent this for other people in the future I added a safeguard.

In addition I also changed:
- [ ] self => this
- [ ] const/let
- [ ] arrow functions
- [ ] helper functions for tests
- [ ] travis runs `lint` and `test`
- [ ] shutdown also summary interval