### PR TITLE
Allow setting unit on `put`, `putSummary` and `sample`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cloudwatchMetrics.initialize({
 
 ### Metric creation
 For creating a metric, we simply need to provide the
-namespace and the type of metric:
+namespace and the default type of metric:
 ```js
 var myMetric = new cloudwatchMetrics.Metric('namespace', 'Count');
 ```
@@ -73,7 +73,7 @@ storageResolution | The metric storage resolution to use in seconds. Set to 1 fo
 ### Publishing metric data
 Then, whenever we want to publish a metric, we simply do:
 ```js
-myMetric.put(value, metric, additionalDimensions);
+myMetric.put(value, metric, units, additionalDimensions);
 ```
 
 ### Using summary metrics

--- a/index.js
+++ b/index.js
@@ -153,9 +153,11 @@ function Metric(namespace, units, defaultDimensions, options) {
  */
 Metric.prototype.put = function(...args) {
   if (args.length === 3) {
-    const units = Array.isArray(args[2]) ? this.units : args[2];
-    const additionalDimensions = Array.isArray(args[2]) ? args[2] : [];
-    return this._put(args[0], args[1], units, additionalDimensions);
+    const [value, metricName] = args;
+    const shouldInheritUnits = Array.isArray(args[2]);
+    const units = shouldInheritUnits ? this.units : args[2];
+    const additionalDimensions = shouldInheritUnits ? args[2] : [];
+    return this._put(value, metricName, units, additionalDimensions);
   } else if (args.length === 2) {
     return this._put(...args, this.units);
   }
@@ -206,8 +208,9 @@ Metric.prototype._put = function(value, metricName, units, additionalDimensions)
 Metric.prototype.summaryPut = function(...args) {
   if (args.length === 3) {
     const [value, metricName] = args;
-    const units = Array.isArray(args[2]) ? this.units : args[2];
-    const additionalDimensions = Array.isArray(args[2]) ? args[2] : [];
+    const shouldInheritUnits = Array.isArray(args[2]);
+    const units = shouldInheritUnits ? this.units : args[2];
+    const additionalDimensions = shouldInheritUnits ? args[2] : [];
     return this._summaryPut(value, metricName, units, additionalDimensions);
   } else if (args.length === 2) {
     return this._summaryPut(...args, this.units, []);

--- a/index.js
+++ b/index.js
@@ -147,18 +147,29 @@ function Metric(namespace, units, defaultDimensions, options) {
  * Publish this data to Cloudwatch
  * @param {Integer|Long} value          Data point to submit
  * @param {String} namespace            Name of the metric
- * @param {Array} additionalDimensions  Array of additional CloudWatch metric dimensions. See
+ * @param {String} units                CloudWatch units
+ * @param {Array} [additionalDimensions]  Array of additional CloudWatch metric dimensions. See
  * http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html for details.
  */
-Metric.prototype.put = function(value, metricName, additionalDimensions) {
+Metric.prototype.put = function(...args) {
+  if (args.length === 3) {
+    const units = Array.isArray(args[2]) ? this.units : args[2];
+    const additionalDimensions = Array.isArray(args[2]) ? args[2] : [];
+    return this._put(args[0], args[1], units, additionalDimensions);
+  } else if (args.length === 2) {
+    return this._put(...args, this.units);
+  }
+  return this._put(...args);
+};
+
+Metric.prototype._put = function(value, metricName, units, additionalDimensions) {
   var self = this;
   // Only publish if we are enabled
   if (self.options.enabled) {
-    additionalDimensions = additionalDimensions || [];
     var payload = {
       MetricName: metricName,
       Dimensions: self.defaultDimensions.concat(additionalDimensions),
-      Unit: self.units,
+      Unit: units,
       Value: value
     };
     if (this.options.withTimestamp) {
@@ -189,19 +200,32 @@ Metric.prototype.put = function(value, metricName, additionalDimensions) {
  * Metric instance to track those two summary sets independently!
  * @param {Number} value The value to include in the summary.
  * @param {String} metricName The name of the metric we're summarizing.
+ * @param {String} units CloudWatch units
  * @param {Object[]} additionalDimensions The extra dimensions we're tracking.
  */
-Metric.prototype.summaryPut = function(value, metricName, additionalDimensions = []) {
-  const key = makeKey(metricName, additionalDimensions);
+Metric.prototype.summaryPut = function(...args) {
+  if (args.length === 3) {
+    const [value, metricName] = args;
+    const units = Array.isArray(args[2]) ? this.units : args[2];
+    const additionalDimensions = Array.isArray(args[2]) ? args[2] : [];
+    return this._summaryPut(value, metricName, units, additionalDimensions);
+  } else if (args.length === 2) {
+    return this._summaryPut(...args, this.units, []);
+  }
+  return this._summaryPut(...args);
+};
+
+Metric.prototype._summaryPut = function(value, metricName, units, additionalDimensions = []) {
+  const key = makeKey(metricName, units, additionalDimensions);
   const entry = this._summaryData.get(key);
 
   let set;
   if (entry) {
-    set = entry[2];
+    set = entry[3];
   } else {
     set = new SummarySet();
     const allDimensions = [...this.defaultDimensions, ...additionalDimensions];
-    this._summaryData.set(key, [metricName, allDimensions, set]);
+    this._summaryData.set(key, [metricName, units, allDimensions, set]);
   }
   set.put(value);
 };
@@ -211,6 +235,7 @@ Metric.prototype.summaryPut = function(value, metricName, additionalDimensions =
  * sampleRate.
  * @param {Integer|Long} value          Data point to submit
  * @param {String} namespace            Name of the metric
+ * @param {String} units                CloudWatch units
  * @param {Array} additionalDimensions  Array of additional CloudWatch metric dimensions. See
  * http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html for details.
  * @param  {Float} sampleRate           The rate at which to sample the metric at.
@@ -218,8 +243,19 @@ Metric.prototype.summaryPut = function(value, metricName, additionalDimensions =
  *    a sampleRate of 0.1, then we will send the metric to Cloudwatch 10% of the
  *    time.
  */
-Metric.prototype.sample = function(value, metricName, additionalDimensions, sampleRate) {
-  if (Math.random() < sampleRate) this.put(value, metricName, additionalDimensions);
+Metric.prototype.sample = function(...args) {
+  if (args.length === 4) {
+    const [value, metricName, additionalDimensions, sampleRate] = args;
+    const units = this.units;
+    return this._sample(value, metricName, units, additionalDimensions, sampleRate);
+  }
+
+  return this.prototype._sample(...args);
+};
+
+Metric.prototype._sample = function(value, metricName, units, additionalDimensions, sampleRate) {
+  sampleRate = Array.isArray(additionalDimensions) ? sampleRate : additionalDimensions;
+  if (Math.random() < sampleRate) this.put(value, metricName, units, additionalDimensions);
 };
 
 /**
@@ -267,14 +303,14 @@ Metric.prototype.hasMetrics = function() {
 Metric.prototype._summarizeMetrics = function() {
   const summaryEntries = this._summaryData.values();
   const dataPoints = [];
-  for (const [MetricName, Dimensions, set] of summaryEntries) {
+  for (const [MetricName, Unit, Dimensions, set] of summaryEntries) {
     if (!set.size) continue;
 
     dataPoints.push({
       MetricName,
       Dimensions,
       StatisticValues: set.get(),
-      Unit: this.units,
+      Unit,
     });
 
     if (dataPoints.length === this.options.maxCapacity) {
@@ -307,11 +343,12 @@ Metric.prototype._putSummaryMetrics = function(MetricData) {
  * or dimension name/value.
  *
  * @param {String} metricName
+ * @param {String} units
  * @param {Object[]} dimensions
  * @returns {String} Something we can actually use as a Map key.
  */
-function makeKey(metricName, dimensions) {
-  let key = metricName;
+function makeKey(metricName, units, dimensions) {
+  let key = `${metricName}\0${units}`;
   for (const {Name, Value} of dimensions) {
     key += `\0${Name}\0${Value}`;
   }

--- a/spec/src/indexSpec.js
+++ b/spec/src/indexSpec.js
@@ -205,6 +205,37 @@ describe('cloudwatch-metrics', function() {
 
       metric.put(1, 'metricName', [{Name: 'ExtraDimension', Value: 'Value'}]);
     });
+
+    it('should override the Unit from the namespace if specified in the put call', function (done) {
+      attachHook(function (data, cb) {
+        expect(data).toEqual({
+          MetricData: [{
+            Dimensions: [{
+              Name: 'environment',
+              Value: 'PROD'
+            }, {
+              Name: 'ExtraDimension',
+              Value: 'Value'
+            }],
+            MetricName: 'metricName',
+            Unit: 'Percent',
+            Value: 1
+          }],
+          Namespace: 'namespace'
+        });
+        cb();
+      });
+
+      const metric = new cloudwatchMetric.Metric('namespace', 'Count', [{
+        Name: 'environment',
+        Value: 'PROD'
+      }], {
+        sendInterval: 1000,
+        sendCallback: done,
+      });
+
+      metric.put(1, 'metricName', 'Percent', [{ Name: 'ExtraDimension', Value: 'Value' }]);
+    });
   });
 
   describe('sample', function() {
@@ -297,6 +328,22 @@ describe('cloudwatch-metrics', function() {
               Sum: 2,
               SampleCount: 1,
             },
+          }, {
+            Dimensions: [{
+              Name: 'environment',
+              Value: 'PROD'
+            }, {
+              Name: 'ExtraDimension',
+              Value: 'Value'
+            }],
+            MetricName: 'a-metric-with-different-unit',
+            Unit: 'Percent',
+            StatisticValues: {
+              Minimum: 5,
+              Maximum: 5,
+              Sum: 5,
+              SampleCount: 1,
+            },
           }],
           Namespace: 'namespace'
         });
@@ -314,8 +361,9 @@ describe('cloudwatch-metrics', function() {
         },
       });
 
-      metric.summaryPut(12, 'some-metric', [{Name: 'ExtraDimension', Value: 'Value'}]);
-      metric.summaryPut(2, 'some-other-metric', [{Name: 'ExtraDimension', Value: 'Value'}]);
+      metric.summaryPut(12, 'some-metric', [{ Name: 'ExtraDimension', Value: 'Value' }]);
+      metric.summaryPut(2, 'some-other-metric', [{ Name: 'ExtraDimension', Value: 'Value' }]);
+      metric.summaryPut(5, 'a-metric-with-different-unit', 'Percent', [{ Name: 'ExtraDimension', Value: 'Value' }]);
       setTimeout(() => {
         metric.summaryPut(13, 'some-metric', [{Name: 'ExtraDimension', Value: 'Value'}]);
       }, 50);


### PR DESCRIPTION
#### Changes Made

`put`, `putSummary` and `sample` now all accept a `units` argument, allowing you to have multiple metrics for the same namespace with different units. For example:

```js
const namespace = new Metric('Server', 'Count');

namespace.put(1, 'RequestCount')
namespace.put(500, 'RequestBodySize', 'Bytes')
```

The implementation gets a little funky because I didn't want to break backwards compatibility, while still retaining a logical argument order. So the way I have implemented it, both the old function signatures and the new ones should work:

```js
const dimensions = [{ Name: 'environment', Value: 'production' }]

// `units` will be inherited from the namespace and the dimensions will be respected
namespace.put(1, 'RequestCount', dimensions)

// Overrides `units` from the namespace
namespace.put(500, 'RequestBodySize', 'Bytes', dimensions)
```

Fixes #13

#### Potential Risks

* The tests are updated to include usages of both the new and old signatures, but if there is a mistake that the tests don't catch, the likely result would be that the `dimensions` will be used as the unit, which I would assume would cause CloudWatch to reject the request.
* Having functions that accept a variable number of arguments is pretty gnarly to maintain, so in the long run I would advocate for a breaking change that removes the unit from the namespace and requires it on the metric itself, but that's just my recommendation.

#### Test Plan

* The automated tests are testing both the new and old function signatures.

#### Checklist
- [x] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
