### PR TITLE
fix: PutMetricData Timestamp should be a Date

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ Metric.prototype._put = function(value, metricName, units, additionalDimensions 
       Value: value
     };
     if (this.options.withTimestamp) {
-      payload.Timestamp = new Date().toISOString();
+      payload.Timestamp = new Date();
     }
     if (this.options.storageResolution) {
       payload.StorageResolution = this.options.storageResolution;

--- a/spec/src/indexSpec.js
+++ b/spec/src/indexSpec.js
@@ -152,12 +152,12 @@ describe('cloudwatch-metrics', function() {
             }],
             MetricName: 'metricName',
             Unit: 'Count',
-            Timestamp: jasmine.any(String),
+            Timestamp: jasmine.any(Date),
             Value: 1
           }],
           Namespace: 'namespace'
         }}));
-        expect(Date.parse(data.input.MetricData[0].Timestamp)).toBeLessThanOrEqual(Date.now());
+        expect(data.input.MetricData[0].Timestamp).toBeLessThanOrEqual(Date.now());
         cb();
       });
 


### PR DESCRIPTION
## 📚 Context/Description Behind The Change

In version 1.3.3, `cloudwatch-metrics` is throwing when using the option `{withTimestamp: true}`.

The AWS SDK specifies that Timestamp should be of Date type per MetricDatum spec. In version `cloudwatch-metrics@1.3.3` is sending a string instead.

Sources:

https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-cloudwatch/src/models/models_0.ts#L4491-L4496

https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-cloudwatch/Interface/PutMetricDataCommandInput/

Error when using `cloudwatch-metrics@1.3.3`.

```
TypeError: input.Timestamp.toISOString is not a function
    at se_MetricDatum (/Users/irae/code/consider/web-fe/node_modules/@aws-sdk/client-cloudwatch/dist-cjs/protocols/Aws_query.js:2768:48)
    at se_MetricData (/Users/irae/code/consider/web-fe/node_modules/@aws-sdk/client-cloudwatch/dist-cjs/protocols/Aws_query.js:2700:31)
    at se_PutMetricDataInput (/Users/irae/code/consider/web-fe/node_modules/@aws-sdk/client-cloudwatch/dist-cjs/protocols/Aws_query.js:3248:31)
    at se_PutMetricDataCommand (/Users/irae/code/consider/web-fe/node_modules/@aws-sdk/client-cloudwatch/dist-cjs/protocols/Aws_query.js:355:12)
    at serialize (/Users/irae/code/consider/web-fe/node_modules/@aws-sdk/client-cloudwatch/dist-cjs/commands/PutMetricDataCommand.js:40:56)
    at /Users/irae/code/consider/web-fe/node_modules/@smithy/middleware-serde/dist-cjs/serializerMiddleware.js:12:27
    at /Users/irae/code/consider/web-fe/node_modules/@smithy/middleware-endpoint/dist-cjs/endpointMiddleware.js:20:16
    at async /Users/irae/code/consider/web-fe/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26
```

To reproduce error and test the fix:
```js
const cloudwatchMetrics = require('cloudwatch-metrics');
const {Metric} = cloudwatchMetrics;

cloudwatchMetrics.initialize({
    region: 'us-west-2',
});

const apiMetrics = new Metric(
    'EmailMetrics',
    'Count',
    [
        {
            Name: 'environment',
            Value: 'dev-irae',
        },
    ],
    {
        enabled: true,
        sendCallback: (error, data) => {
            error && console.error(error);
            data !== undefined && console.log(data);
        },
        sendInterval: 100,
        summaryInterval: 200,
        withTimestamp: true,
    }
);

apiMetrics.put(12, 'lastDay', 'Count', [
    {
        Name: 'EmailType',
        Value: 'listlog-added',
    },
]);

apiMetrics.shutdown();
```


## 🚨 Potential Risks & What To Monitor After Deployment

None

## 🧑‍🔬 How Has This Been Tested?

- Updating `cloudwatch-metrics` to 1.3.3 on my product branch it throws. When linking the proposed change it fixes the issue in my codebase
- Example code provided breaks on 1.3.3 and is fixed by this PR


## 🚚 Release Plan

Bump version to 1.3.4 and publish npm package.
